### PR TITLE
Add more Postgres support

### DIFF
--- a/examples/postgres/docker-compose.yaml
+++ b/examples/postgres/docker-compose.yaml
@@ -1,0 +1,14 @@
+---
+services:
+  postgres:
+    image: postgres:15
+    ports:
+      - 5432:5432
+    volumes:
+      - pg-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
+      POSTGRES_DB: example
+
+volumes:
+  pg-data:

--- a/examples/postgres/main.go
+++ b/examples/postgres/main.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"github.com/shoekstra/go-dbmanager"
+)
+
+func main() {
+	databaseName := "mytestdb"
+	username, password := "mytestuser", "password"
+
+	// Example usage with PostgreSQL
+	dbm, err := dbmanager.New(
+		"postgres",
+		dbmanager.WithHost("localhost"),
+		dbmanager.WithUsername("postgres"),
+		dbmanager.WithPassword("password"),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	// Connect to server
+	if err := dbm.Connect(); err != nil {
+		panic(err)
+	}
+	defer dbm.Disconnect()
+
+	// Create user: this always needs to happen first otherwise the default privileges cannot be set
+	if err := dbm.CreateUser(dbmanager.User{Name: username, Password: password}); err != nil {
+		panic(err)
+	}
+
+	defaultPrivileges := []dbmanager.DefaultPrivilege{
+		{Role: "postgres", Schema: "public", Grant: []string{"ALL"}, On: "tables", To: username},
+		{Role: "postgres", Schema: "public", Grant: []string{"USAGE", "SELECT"}, On: "SEQUENCES", To: username},
+	}
+
+	// Create database
+	if err := dbm.CreateDatabase(dbmanager.Database{Name: databaseName, DefaultPrivileges: defaultPrivileges}); err != nil {
+		panic(err)
+	}
+
+	// Assign privileges to user
+	grants := []dbmanager.Grant{
+		{Database: databaseName, Privileges: []string{"ALL"}},
+		{Database: databaseName, Privileges: []string{"USAGE", "SELECT"}, Schema: "public", Sequence: "*"},
+		{Database: databaseName, Privileges: []string{"ALL"}, Schema: "public", Table: "*"},
+	}
+	if err := dbm.GrantPermissions(username, databaseName, grants); err != nil {
+		panic(err)
+	}
+}

--- a/manager.go
+++ b/manager.go
@@ -13,6 +13,7 @@ type Manager interface {
 	DatabaseExists(databaseName string) (bool, error)
 	CreateUser(userConfig User) error
 	UserExists(username string) (bool, error)
+	GrantPermissions(username, databaseName string, grants []Grant) error
 }
 
 // databaseManager is the internal implementation of the Manager interface
@@ -30,7 +31,39 @@ func (m *databaseManager) initialize(options ...func(*Connection)) {
 
 // Database represents the configuration for creating a database
 type Database struct {
-	Name string `json:"name"`
+	Name              string             `json:"name"`
+	DefaultPrivileges []DefaultPrivilege `json:"default_privileges"`
+}
+
+// DefaultPrivilege contains the default privileges in a database for a user or role.
+type DefaultPrivilege struct {
+	Role      string   `json:"role"`
+	Schema    string   `json:"schema"`
+	Grant     []string `json:"grant"`
+	On        string   `json:"on"`
+	To        string   `json:"to"`
+	WithGrant bool     `json:"with_grant"`
+}
+
+// Grant represents a set of permissions granted to a user.
+type Grant struct {
+	// Optional: Specify the target database
+	Database string `json:"database"`
+
+	// Optional: Specify the target schema
+	Schema string `json:"schema"`
+
+	// Optional: Specify the target Sequence
+	Sequence string `json:"sequence"`
+
+	// Optional: Specify the target table
+	Table string `json:"table"`
+
+	// Required: List of privileges (e.g., "ALL", "CONNECT", "USAGE", "SELECT", etc.)
+	Privileges []string `json:"privileges"`
+
+	// Optional: Grant option
+	WithGrant bool `json:"with_grant"`
 }
 
 // User represents the configuration for creating a user

--- a/mysql.go
+++ b/mysql.go
@@ -54,3 +54,8 @@ func (m *mysqlManager) UserExists(name string) (bool, error) {
 	// Additional MySQL specific logic to check if a user exists
 	return false, nil
 }
+
+// GrantPermissions grants permissions to a user based on the provided Grant options.
+func (m *mysqlManager) GrantPermissions(username, database string, grants []Grant) error {
+	return nil
+}

--- a/postgres_test.go
+++ b/postgres_test.go
@@ -16,15 +16,18 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var postgresTestManager Manager
-var resource *dockertest.Resource
-var adminUser, adminPassword string
+var (
+	postgresTestManager Manager
+	resource            *dockertest.Resource
+
+	adminUser, adminPassword string = "postgres", "password"
+	username, password       string = "mytestuser", "mypassword"
+	database                 string = "mytestdb"
+)
 
 func TestMain(m *testing.M) {
 	// Disable log output for tests
 	log.SetOutput(io.Discard)
-
-	adminUser, adminPassword = "postgres", "password"
 
 	// uses a sensible default on windows (tcp/http) and linux/osx (socket)
 	pool, err := dockertest.NewPool("")
@@ -95,28 +98,7 @@ func TestPostgresManager_ConnectIntegration(t *testing.T) {
 	assert.NoError(t, postgresTestManager.Connect(), "Error connecting to database")
 }
 
-func TestPostgresManager_CreateDatabaseIntegration_Basic(t *testing.T) {
-	// Test database name
-	databaseName := "mytestdb"
-
-	// Perform the actual operation
-	err := postgresTestManager.CreateDatabase(Database{Name: databaseName})
-	assert.NoError(t, err, "Error creating database")
-
-	// Check if the database was created successfully
-	exists, err := postgresTestManager.DatabaseExists(databaseName)
-	assert.True(t, exists, "Database not found after CreateDatabase operation")
-	assert.NoError(t, err, "Error checking if database exists")
-
-	// Attempting to create the database again should not return an error
-	err = postgresTestManager.CreateDatabase(Database{Name: databaseName})
-	assert.NoError(t, err, "Error creating database when it already exists")
-}
-
 func TestPostgresManager_CreateUserIntegration_Basic(t *testing.T) {
-	// Test user name
-	username := "mytestuser"
-
 	// Perform the actual operation
 	err := postgresTestManager.CreateUser(User{Name: username, Password: "password"})
 	assert.NoError(t, err, "Error creating user")
@@ -131,7 +113,95 @@ func TestPostgresManager_CreateUserIntegration_Basic(t *testing.T) {
 	assert.NoError(t, err, "Error creating user when it already exists")
 }
 
-func TestPostgresManager_CreateDatabaseIntegration(t *testing.T) {
+func TestPostgresManager_CreateDatabaseIntegration_Basic(t *testing.T) {
+	// Perform the actual operation
+	err := postgresTestManager.CreateDatabase(Database{Name: database})
+	assert.NoError(t, err, "Error creating database")
+
+	// Check if the database was created successfully
+	exists, err := postgresTestManager.DatabaseExists(database)
+	assert.True(t, exists, "Database not found after CreateDatabase operation")
+	assert.NoError(t, err, "Error checking if database exists")
+
+	// Attempting to create the database again should not return an error
+	err = postgresTestManager.CreateDatabase(Database{Name: database})
+	assert.NoError(t, err, "Error creating database when it already exists")
+}
+
+func TestPostgresManager_CreateDatabaseIntegration_AlterDefaultPrivileges(t *testing.T) {
+	// Create database with default privileges should fail because the user does not exist yet
+	defaultPrivileges := []DefaultPrivilege{
+		{Role: "postgres", Schema: "public", Grant: []string{"ALL"}, On: "tables", To: "username"},
+		{Role: "postgres", Schema: "public", Grant: []string{"USAGE", "SELECT"}, On: "SEQUENCES", To: "username"},
+	}
+	err := postgresTestManager.CreateDatabase(Database{Name: database, DefaultPrivileges: defaultPrivileges})
+	assert.Error(t, err, "Creating database with default privileges should have failed if user does not exist")
+
+	// Create database with default privileges again should succeed when user exists
+	defaultPrivileges = []DefaultPrivilege{
+		{Role: "postgres", Schema: "public", Grant: []string{"ALL"}, On: "tables", To: username},
+		{Role: "postgres", Schema: "public", Grant: []string{"USAGE", "SELECT"}, On: "SEQUENCES", To: username},
+	}
+	err = postgresTestManager.CreateDatabase(Database{Name: database, DefaultPrivileges: defaultPrivileges})
+	assert.NoError(t, err, "Error creating database with default privileges")
+
+	// Check if the database was created successfully
+	exists, err := postgresTestManager.DatabaseExists(database)
+	assert.True(t, exists, "Database not found after CreateDatabase operation with default privileges")
+	assert.NoError(t, err, "Error checking if database exists")
+
+	// Attempting to create the database again should not return an error
+	err = postgresTestManager.CreateDatabase(Database{Name: database})
+	assert.NoError(t, err, "Error creating database with default privileges when it already exists")
+}
+
+func TestPostgresManager_GrantPermissionsIntegration_Database(t *testing.T) {
+	// Test grant options
+	grants := []Grant{
+		{
+			Database:   database,
+			Privileges: []string{"ALL"},
+		},
+	}
+
+	// Perform the actual operation
+	err := postgresTestManager.GrantPermissions(username, database, grants)
+	assert.NoError(t, err, "Error granting permissions")
+}
+
+func TestPostgresManager_GrantPermissionsIntegration_AllSequences(t *testing.T) {
+	// Test grant options
+	grants := []Grant{
+		{
+			Database:   database,
+			Privileges: []string{"USAGE", "SELECT"},
+			Schema:     "public",
+			Sequence:   "*",
+		},
+	}
+
+	// Perform the actual operation
+	err := postgresTestManager.GrantPermissions(username, database, grants)
+	assert.NoError(t, err, "Error granting permissions")
+}
+
+func TestPostgresManager_GrantPermissionsIntegration_AllTables(t *testing.T) {
+	// Test grant options
+	grants := []Grant{
+		{
+			Database:   database,
+			Privileges: []string{"ALL"},
+			Schema:     "public",
+			Table:      "*",
+		},
+	}
+
+	// Perform the actual operation
+	err := postgresTestManager.GrantPermissions(username, database, grants)
+	assert.NoError(t, err, "Error granting permissions")
+}
+
+func TestPostgresManager_DisconnectIntegration(t *testing.T) {
 	// Test disconnection
 	assert.NoError(t, postgresTestManager.Disconnect(), "Error disconnecting from database")
 }


### PR DESCRIPTION
* Add `examples/postgres` with a Docker compose file for an interactive test/example.
* Set default privileges in a database, this is run at database create time.
* Configure user privileges for existing objects in a database.

Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>
