### PR TITLE
Add fixes for RDS Postgres and some hasPermission bugs

### DIFF
--- a/postgres_grant.go
+++ b/postgres_grant.go
@@ -40,6 +40,7 @@ func (m *postgresManager) GrantPermissions(user User) error {
 func (m *postgresManager) addRole(username, role string) error {
 	// Check if the user is trying to add themselves to the role
 	if username == role {
+		log.Printf("User %s is trying to add themselves to role %s, skipping\n", username, role)
 		return nil
 	}
 
@@ -81,6 +82,7 @@ func (m *postgresManager) hasRole(username, role string) (bool, error) {
 func (m *postgresManager) removeRole(username, role string) error {
 	// Check if the user is trying to remove themselves from the role
 	if username == role {
+		log.Printf("User %s is trying to remove themselves from role %s, skipping\n", username, role)
 		return nil
 	}
 

--- a/postgres_user.go
+++ b/postgres_user.go
@@ -9,7 +9,21 @@ import (
 
 // CreateUser creates and manages a user. It will create the user if it doesn't already exist.
 func (m *postgresManager) CreateUser(user User) error {
-	// Check if the user already exists
+	// Create the user if it doesn't already exist
+	if err := m.createUser(user); err != nil {
+		return err
+	}
+
+	// Update the user
+	if err := m.updateUser(user); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// createUser creates a new user.
+func (m *postgresManager) createUser(user User) error {
 	if exists, err := m.userExists(user.Name); err != nil {
 		return err
 	} else if exists {

--- a/postgres_user.go
+++ b/postgres_user.go
@@ -9,14 +9,29 @@ import (
 
 // CreateUser creates and manages a user. It will create the user if it doesn't already exist.
 func (m *postgresManager) CreateUser(user User) error {
-	// Create the user if it doesn't already exist
-	if err := m.createUser(user); err != nil {
+	exists, err := m.userExists(user.Name)
+	if err != nil {
 		return err
 	}
 
-	// Update the user
-	if err := m.updateUser(user); err != nil {
-		return err
+	// If the user doesn't exist, create it, otherwise update it
+	if !exists {
+		if err := m.createUser(user); err != nil {
+			return err
+		}
+		log.Printf("Created user: %s\n", user.Name)
+	} else {
+		if err := m.updateUser(user); err != nil {
+			return err
+		}
+		log.Printf("Updated user: %s\n", user.Name)
+	}
+
+	// We can't read back the user's password, so if one is set, we'll just set it again
+	if user.Password != "" {
+		if err := m.setPassword(user.Name, user.Password); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -24,13 +39,6 @@ func (m *postgresManager) CreateUser(user User) error {
 
 // createUser creates a new user.
 func (m *postgresManager) createUser(user User) error {
-	if exists, err := m.userExists(user.Name); err != nil {
-		return err
-	} else if exists {
-		log.Printf("User %s already exists, skipping\n", user.Name)
-		return nil
-	}
-
 	query := "CREATE"
 
 	// If a password is set, we're creating a user, otherwise we're creating a role/group
@@ -67,26 +75,20 @@ func (m *postgresManager) userExists(name string) (bool, error) {
 
 // updateUser updates the specified user.
 func (m *postgresManager) updateUser(user User) error {
-	// Check if the user already exists
-	if exists, err := m.userExists(user.Name); err != nil {
-		return err
-	} else if !exists {
-		log.Printf("User %s does not exist, skipping\n", user.Name)
-		return nil
+	updated := false
+
+	if updated {
+		log.Printf("Updated user: %s\n", user.Name)
 	}
 
-	// Update the user
-	query := fmt.Sprintf("ALTER USER %s", QuoteIdentifier(user.Name))
+	return nil
+}
 
-	if user.Password != "" {
-		query += fmt.Sprintf(" WITH LOGIN PASSWORD '%s'", user.Password)
-	}
-
+// setPassword sets the password for the specified user.
+func (m *postgresManager) setPassword(name, password string) error {
+	query := fmt.Sprintf("ALTER USER %s WITH LOGIN PASSWORD '%s'", QuoteIdentifier(name), password)
 	if _, err := m.db.Exec(query); err != nil {
 		return err
 	}
-
-	log.Printf("Updated user: %s\n", user.Name)
-
 	return nil
 }

--- a/postgres_user.go
+++ b/postgres_user.go
@@ -9,22 +9,13 @@ import (
 
 // CreateUser creates and manages a user. It will create the user if it doesn't already exist.
 func (m *postgresManager) CreateUser(user User) error {
-	exists, err := m.userExists(user.Name)
-	if err != nil {
+	if exists, err := m.userExists(user.Name); err != nil {
 		return err
-	}
-
-	// If the user doesn't exist, create it, otherwise update it
-	if !exists {
+	} else if !exists {
 		if err := m.createUser(user); err != nil {
 			return err
 		}
 		log.Printf("Created user: %s\n", user.Name)
-	} else {
-		if err := m.updateUser(user); err != nil {
-			return err
-		}
-		log.Printf("Updated user: %s\n", user.Name)
 	}
 
 	// We can't read back the user's password, so if one is set, we'll just set it again
@@ -71,17 +62,6 @@ func (m *postgresManager) userExists(name string) (bool, error) {
 		return false, err
 	}
 	return exists, nil
-}
-
-// updateUser updates the specified user.
-func (m *postgresManager) updateUser(user User) error {
-	updated := false
-
-	if updated {
-		log.Printf("Updated user: %s\n", user.Name)
-	}
-
-	return nil
 }
 
 // setPassword sets the password for the specified user.


### PR DESCRIPTION
RDS `postgres` user is more limited than a traditional `postgres` user
and needs some tricks.

The user creating a database the creator must be a member of the role
when setting another owner or setting default privileges. To get around
this we temporarily add the current user to that role.

Also found `has_database_privilege` returns `true` if any privileges are
set, not all. Assumed the other `has` functions work the same and
amended our functions to instead loop through desired permissions
instead.

Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced database management with updated owner and default privilege handling for RDS compatibility.
  - Improved role management in grants, including the prevention of self-role addition and the ability to remove users from roles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->