### PR TITLE
Refactor user creation and update logic in PostgreSQL manager

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -66,12 +66,37 @@ type Grant struct {
 	WithGrant bool `json:"with_grant"`
 }
 
+// UserOptions represents the configuration for creating a user
+type UserOptions struct {
+	// Login specifies whether the user is allowed to log in to the database. Applicable to PostgreSQL only.
+	Login bool `json:"login"`
+
+	// Superuser specifies whether the user will be a superuser. Applicable to PostgreSQL only.
+	Superuser bool `json:"superuser"`
+
+	// CreateDatabase specifies whether the user will be allowed to create databases. Applicable to PostgreSQL only.
+	CreateDatabase bool `json:"create_database"`
+
+	// CreateRole specifies whether the user will be allowed to create roles. Applicable to PostgreSQL only.
+	CreateRole bool `json:"create_role"`
+
+	// Inherit specifies whether the user will inherit privileges of roles that it is a member of. Applicable to PostgreSQL only.
+	Inherit bool `json:"inherit"`
+
+	// Replication specifies whether the user will be allowed to initiate streaming replication. Applicable to PostgreSQL only.
+	Replication bool `json:"replication"`
+
+	// BypassRLS specifies whether the user will be allowed to bypass row level security policies. Applicable to PostgreSQL only.
+	BypassRLS bool `json:"bypass_rls"`
+}
+
 // User represents the configuration for creating a user
 type User struct {
-	Name     string   `json:"name"`
-	Password string   `json:"password"`
-	Grants   []Grant  `json:"grants"`
-	Roles    []string `json:"roles"`
+	Name     string      `json:"name"`
+	Password string      `json:"password"`
+	Options  UserOptions `json:"options"`
+	Grants   []Grant     `json:"grants"`
+	Roles    []string    `json:"roles"`
 }
 
 // New creates a new Manager instance based on the provided engine.

--- a/postgres_user.go
+++ b/postgres_user.go
@@ -4,17 +4,25 @@ import (
 	"database/sql"
 	"fmt"
 	"log"
+	"strings"
 )
 
 // CreateUser creates and manages a user. It will create the user if it doesn't already exist.
 func (m *postgresManager) CreateUser(user User) error {
-	if exists, err := m.userExists(user.Name); err != nil {
+
+	// If the user already exists, we'll update it, otherwise we'll create it
+	exists, err := m.userExists(user.Name)
+	if err != nil {
 		return err
-	} else if !exists {
-		if err := m.createUser(user); err != nil {
+	}
+	if !exists {
+		if _, err := m.createUser(user); err != nil {
 			return err
 		}
-		log.Printf("Created user: %s\n", user.Name)
+	} else {
+		if _, err := m.updateUser(user); err != nil {
+			return err
+		}
 	}
 
 	// We can't read back the user's password, so if one is set, we'll just set it again
@@ -28,28 +36,152 @@ func (m *postgresManager) CreateUser(user User) error {
 }
 
 // createUser creates a new user.
-func (m *postgresManager) createUser(user User) error {
+func (m *postgresManager) createUser(user User) (bool, error) {
 	query := "CREATE"
 
-	// If a password is set, we're creating a user, otherwise we're creating a role/group
-	if user.Password != "" {
+	// If the user has a password or explicitly set login to true, we'll create a user, otherwise we'll create a role
+	if user.Options.Login || user.Password != "" {
 		query += " USER"
 	} else {
 		query += " ROLE"
 	}
 	query += fmt.Sprintf(" %s", QuoteIdentifier(user.Name))
 
+	addOption := func(option string) {
+		if strings.HasSuffix(query, QuoteIdentifier(user.Name)) {
+			query += " WITH"
+		}
+		query += " " + option
+	}
+
 	if user.Password != "" {
-		query += fmt.Sprintf(" WITH LOGIN PASSWORD '%s'", user.Password)
+		addOption(fmt.Sprintf("LOGIN PASSWORD '%s'", user.Password))
+	}
+
+	if user.Options.Superuser {
+		addOption("SUPERUSER")
+	}
+
+	if user.Options.CreateRole {
+		addOption("CREATEROLE")
+	}
+
+	if user.Options.CreateDatabase {
+		addOption("CREATEDB")
+	}
+
+	if user.Options.Inherit {
+		addOption("INHERIT")
+	}
+
+	if user.Options.Replication {
+		addOption("REPLICATION")
+	}
+
+	if user.Options.BypassRLS {
+		addOption("BYPASSRLS")
 	}
 
 	if _, err := m.db.Exec(query); err != nil {
-		return err
+		return false, err
 	}
 
 	log.Printf("Created user: %s\n", user.Name)
 
-	return nil
+	return true, nil
+}
+
+// getUser returns the user with the specified name.
+func (m *postgresManager) getUser(name string) (User, error) {
+	var user User
+	query := "SELECT rolname, rolsuper, rolcreaterole, rolcreatedb, rolcanlogin, rolinherit, rolreplication, rolbypassrls FROM pg_roles WHERE rolname = $1"
+	err := m.db.QueryRow(query, name).Scan(&user.Name, &user.Options.Superuser, &user.Options.CreateRole, &user.Options.CreateDatabase, &user.Options.Login, &user.Options.Inherit, &user.Options.Replication, &user.Options.BypassRLS)
+	if err != nil {
+		return User{}, err
+	}
+	return user, nil
+}
+
+// updateUser updates the specified user.
+func (m *postgresManager) updateUser(user User) (bool, error) {
+	query := fmt.Sprintf("ALTER USER %s", QuoteIdentifier(user.Name))
+
+	addOption := func(option string) {
+		if strings.HasSuffix(query, QuoteIdentifier(user.Name)) {
+			query += " WITH"
+		}
+		query += " " + option
+	}
+
+	// Compare with real user
+	realUser, err := m.getUser(user.Name)
+	if err != nil {
+		return false, err
+	}
+
+	if user.Options.Superuser != realUser.Options.Superuser {
+		if user.Options.Superuser {
+			addOption("SUPERUSER")
+		} else {
+			addOption("NOSUPERUSER")
+		}
+	}
+
+	if user.Options.CreateRole != realUser.Options.CreateRole {
+		if user.Options.CreateRole {
+			addOption("CREATEROLE")
+		} else {
+			addOption("NOCREATEROLE")
+		}
+	}
+
+	if user.Options.CreateDatabase != realUser.Options.CreateDatabase {
+		if user.Options.CreateDatabase {
+			addOption("CREATEDB")
+		} else {
+			addOption("NOCREATEDB")
+		}
+	}
+
+	if user.Options.Login != realUser.Options.Login {
+		if user.Options.Login {
+			addOption("LOGIN")
+		} else {
+			addOption("NOLOGIN")
+		}
+	}
+
+	if user.Options.Inherit != realUser.Options.Inherit {
+		if user.Options.Inherit {
+			addOption("INHERIT")
+		} else {
+			addOption("NOINHERIT")
+		}
+	}
+
+	if user.Options.Replication != realUser.Options.Replication {
+		if user.Options.Replication {
+			addOption("REPLICATION")
+		} else {
+			addOption("NOREPLICATION")
+		}
+	}
+
+	if user.Options.BypassRLS != realUser.Options.BypassRLS {
+		if user.Options.BypassRLS {
+			addOption("BYPASSRLS")
+		} else {
+			addOption("NOBYPASSRLS")
+		}
+	}
+
+	if _, err := m.db.Exec(query); err != nil {
+		return false, err
+	}
+
+	log.Printf("Updated user: %s\n", user.Name)
+
+	return true, nil
 }
 
 // userExists checks if the specified user exists.


### PR DESCRIPTION
This adds additional options for a role/user which are applied when
creating or now updating a user. Also adds a `getUser` method to read
back a role's properties to make this a bit more idempotent and to
improve test assertions.

Updated `createUser` so that it specifies the LOGIN flag either when a
password is set or the `Options.Login` is explicitly set (this is needed
when configuring another authentication method, like IAM).

Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced user creation with additional configuration options, including password settings.
	- Improved user management with capabilities to retrieve and update user details.

- **Bug Fixes**
	- Refined logic in user creation to handle updates based on user existence.

- **Tests**
	- Added new test cases to verify the creation of users with various options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->