### PR TITLE
Add support for granting permissions on PostgreSQL parameters

### DIFF
--- a/examples/postgres_manage/config.json
+++ b/examples/postgres_manage/config.json
@@ -11,13 +11,14 @@
     ],
     "users": [
         {
-            "name": "testowner"
+            "name": "testowner",
+            "roles": ["postgres"]
         },
         {
             "name": "testuser",
             "password": "testpassword",
-            "roles": ["postgres"],
             "grants": [
+                { "parameter": "session_replication_role", "privileges": ["SET"] },
                 { "database": "testdb", "privileges": ["ALL"] },
                 { "database": "testdb", "privileges": ["USAGE", "SELECT"], "schema": "public", "sequence": "*" },
                 { "database": "testdb", "privileges": ["ALL"], "schema": "public", "table": "*" }

--- a/manager.go
+++ b/manager.go
@@ -59,6 +59,9 @@ type Grant struct {
 	// Optional: Specify the target table
 	Table string `json:"table"`
 
+	// Optional: Specify the target parameter (PostgreSQL only)
+	Parameter string `json:"parameter"`
+
 	// Required: List of privileges (e.g., "ALL", "CONNECT", "USAGE", "SELECT", etc.)
 	Privileges []string `json:"privileges"`
 


### PR DESCRIPTION
Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced the capability to set specific parameters for user permissions in databases.
- **Bug Fixes**
	- Fixed an issue where permissions were incorrectly granted when the database field was empty but a parameter was specified.
- **Tests**
	- Added integration tests to ensure the correct functionality of setting user parameters and permission handling in databases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->